### PR TITLE
Add table view for search entries

### DIFF
--- a/LFGAnalyzer.lua
+++ b/LFGAnalyzer.lua
@@ -1,6 +1,9 @@
 local LFGAnalyzer = CreateFrame("Frame")
 LFGAnalyzer:RegisterEvent("CHAT_MSG_CHANNEL")
 
+-- gespeicherte Einträge für die UI
+local entries = {}
+
 local buffer = {}
 local lastSender = nil
 local lastTimestamp = 0
@@ -13,15 +16,106 @@ local bossToRaid = {
     ["lord mark'gar"] = "ICC"
 }
 
+-- extrahiert Rolleninformatioen aus einer Nachricht
+local function parseRoles(msg)
+    local roles = { tank = 0, heal = 0, dps = 0, ranged = 0, melee = 0 }
+    local n
+
+    n = tonumber(msg:match("(%d+)%s*tanks?"))
+    if n then roles.tank = n elseif msg:match("tank") then roles.tank = 1 end
+
+    n = tonumber(msg:match("(%d+)%s*heals?")) or tonumber(msg:match("(%d+)%s*heiler"))
+    if n then roles.heal = n elseif msg:match("heal") or msg:match("heiler") then roles.heal = 1 end
+
+    n = tonumber(msg:match("(%d+)%s*dps")) or tonumber(msg:match("(%d+)%s*dds?"))
+    if n then roles.dps = n elseif msg:match("dps") or msg:match("dd") then roles.dps = 1 end
+
+    if msg:match("range") or msg:match("rdd") then roles.ranged = roles.dps end
+    if msg:match("melee") or msg:match("mdd") then roles.melee = roles.dps end
+
+    return roles
+end
+
+local function updateEntry(sender, raids, roles, text)
+    local entry = entries[sender]
+    if not entry then
+        entry = { sender = sender }
+        entries[sender] = entry
+    end
+
+    entry.raids = table.concat(raids, ", ")
+    entry.roles = roles
+    entry.text = text
+    entry.time = time()
+
+    if LFGAnalyzer.frame and LFGAnalyzer.frame:IsShown() then
+        LFGAnalyzer.refreshUI()
+    end
+end
+
 local function resetBuffer()
     buffer = {}
     lastSender = nil
     lastTimestamp = 0
 end
 
+-- UI erstellen
+local function createUI()
+    if LFGAnalyzer.frame then return end
+
+    local f = CreateFrame("Frame", "LFGAnalyzerFrame", UIParent, "BackdropTemplate")
+    f:SetSize(400, 200)
+    f:SetPoint("CENTER")
+    f:SetBackdrop({ bgFile = "Interface/Tooltips/UI-Tooltip-Background" })
+    f:SetBackdropColor(0, 0, 0, 0.8)
+
+    f.title = f:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    f.title:SetPoint("TOP", 0, -10)
+    f.title:SetText("LFG Analyzer")
+
+    f.rows = {}
+    f:Hide()
+
+    LFGAnalyzer.frame = f
+end
+
+function LFGAnalyzer.refreshUI()
+    createUI()
+    local f = LFGAnalyzer.frame
+
+    for _, row in ipairs(f.rows) do
+        row:Hide()
+    end
+
+    local index = 0
+    for _, entry in pairs(entries) do
+        index = index + 1
+        local row = f.rows[index]
+        if not row then
+            row = f:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+            row:SetPoint("TOPLEFT", 10, -20 - (index - 1) * 15)
+            f.rows[index] = row
+        end
+        local r = entry.roles or {}
+        row:SetText(string.format("%s | %s | T:%d H:%d DD:%d", entry.sender, entry.raids or "", r.tank or 0, r.heal or 0, r.dps or 0))
+        row:Show()
+    end
+end
+
+local function toggleUI()
+    createUI()
+    if LFGAnalyzer.frame:IsShown() then
+        LFGAnalyzer.frame:Hide()
+    else
+        LFGAnalyzer.refreshUI()
+        LFGAnalyzer.frame:Show()
+    end
+end
+
 local function analyzeMessage(fullMessage, sender)
     local lower = fullMessage:lower()
     local results = {}
+    local roles = parseRoles(lower)
 
     if lower:match("lfm") or lower:match("suche") or lower:match("suchen") then
         if lower:match("icc") then table.insert(results, "ICC") end
@@ -29,9 +123,9 @@ local function analyzeMessage(fullMessage, sender)
         if lower:match("weekly") then table.insert(results, "Weekly") end
         if lower:match("voa") then table.insert(results, "VoA") end
         if lower:match("muss sterben") then table.insert(results, "Weekly") end
-        if lower:match("%d+ dds") then table.insert(results, "DPS gesucht") end
-        if lower:match("tank") then table.insert(results, "Tank gesucht") end
-        if lower:match("healer") then table.insert(results, "Healer gesucht") end
+        if roles.dps > 0 then table.insert(results, "DPS gesucht") end
+        if roles.tank > 0 then table.insert(results, "Tank gesucht") end
+        if roles.heal > 0 then table.insert(results, "Healer gesucht") end
 
         -- Suche nach Bossnamen
         for boss, raid in pairs(bossToRaid) do
@@ -46,6 +140,7 @@ local function analyzeMessage(fullMessage, sender)
         DEFAULT_CHAT_FRAME:AddMessage(
             string.format("|cff00ff00[Analyzer]|r %s sucht: %s", sender, table.concat(results, ", "))
         )
+        updateEntry(sender, results, roles, fullMessage)
     end
 end
 
@@ -79,4 +174,5 @@ SlashCmdList["LFGANALYZER"] = function()
         analyzeMessage(table.concat(buffer, " "), lastSender)
     end
     resetBuffer()
+    toggleUI()
 end

--- a/LFGAnalyzer.toc
+++ b/LFGAnalyzer.toc
@@ -1,5 +1,5 @@
 ## Interface: 30300
 ## Title: LFG Analyzer
 ## Notes: Analysiert Worldchat-Nachrichten nach LFM/LFG Aktivitäten
-## Version: 1.0
+## Version: 1.1
 LFGAnalyzer.lua


### PR DESCRIPTION
## Summary
- add dataset storage for detected LFG messages
- parse role counts and update entries on repeat messages
- implement simple UI frame listing entries
- toggle the UI with `/lfganalyzer`
- bump addon version

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880e7a67324832b86c7f088707aae2a