### PR TITLE
Fix BackdropTemplate compatibility

### DIFF
--- a/LFGAnalyzer.lua
+++ b/LFGAnalyzer.lua
@@ -63,7 +63,8 @@ end
 local function createUI()
     if LFGAnalyzer.frame then return end
 
-    local f = CreateFrame("Frame", "LFGAnalyzerFrame", UIParent, "BackdropTemplate")
+    -- Compatibility: BackdropTemplate exists only in later client versions
+    local f = CreateFrame("Frame", "LFGAnalyzerFrame", UIParent, BackdropTemplateMixin and "BackdropTemplate" or nil)
     f:SetSize(400, 200)
     f:SetPoint("CENTER")
     f:SetBackdrop({ bgFile = "Interface/Tooltips/UI-Tooltip-Background" })


### PR DESCRIPTION
## Summary
- avoid `Couldn't find inherited node "BackdropTemplate"` error when BackdropTemplateMixin isn't available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880eb438ea4832ba9e801868f52af4a