### PR TITLE
Fix nil call when clicking minimap button

### DIFF
--- a/LFGAnalyzer.lua
+++ b/LFGAnalyzer.lua
@@ -14,6 +14,9 @@ local timeout = 5 -- Sekunden
 local bossToRaid = {}
 local weeklyKeywords = {}
 
+-- forward declarations for functions used before definition
+local toggleUI
+
 -- Mapping bestimmter Bossnamen auf ihre Raids (geladen aus SavedVariables)
 local bossToRaid = {}
 
@@ -238,7 +241,7 @@ function LFGAnalyzer.refreshUI()
     end
 end
 
-local function toggleUI()
+function toggleUI()
     createUI()
     if LFGAnalyzer.frame:IsShown() then
         LFGAnalyzer.frame:Hide()


### PR DESCRIPTION
## Summary
- forward declare `toggleUI`
- define `toggleUI` as local variable to prevent global lookup

## Testing
- `luac -p` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880f169bf5c832b91301cad32f557d2