### PR TITLE
Add weekly keyword list and debug options

### DIFF
--- a/LFGAnalyzer.toc
+++ b/LFGAnalyzer.toc
@@ -1,6 +1,6 @@
 ## Interface: 30300
 ## Title: LFG Analyzer
 ## Notes: Analysiert Worldchat-Nachrichten nach LFM/LFG Aktivitäten
-## Version: 1.2
+## Version: 1.3
 ## SavedVariables: LFGAnalyzerDB
 LFGAnalyzer.lua


### PR DESCRIPTION
## Summary
- add enable and debug variables with chat output helper
- expand config UI with enable & debug checkboxes
- allow weekly keywords to be added/removed individually
- persist enable/debug settings on save
- add minimap dropdown with debug toggle
- bump version

## Testing
- `luac -p LFGAnalyzer.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68810b4f0d9c832ba1197da0bb063625