### PR TITLE
Fix config scroll frame load error

### DIFF
--- a/LFGAnalyzer.lua
+++ b/LFGAnalyzer.lua
@@ -110,7 +110,16 @@ local function createConfigUI()
     f.scrollFrame:SetPoint("TOPLEFT", 10, -30)
     f.scrollFrame:SetPoint("BOTTOMRIGHT", -30, 40)
 
-    local content = CreateFrame("Frame", nil, f.scrollFrame)
+    -- The UIPanelScrollFrameTemplate expects a named child frame called
+    -- <ScrollFrameName>ScrollChildFrame during its OnLoad handler. Without this
+    -- named child, the template's setup triggers an error in older clients.
+    -- Create the content frame with the expected name so the template can find
+    -- it immediately.
+    local content = CreateFrame(
+        "Frame",
+        "LFGAnalyzerConfigScrollFrameScrollChildFrame",
+        f.scrollFrame
+    )
     content:SetSize(360, 1)
     content:SetPoint("TOPLEFT")
     f.scrollFrame:SetScrollChild(content)


### PR DESCRIPTION
## Summary
- name the configuration scroll frame's child so the UIPanel scroll template finds it

## Testing
- `luac` command failed: command not found

------
https://chatgpt.com/codex/tasks/task_e_688139cc07b4832bbd04bc54b265b085