### PR TITLE
Fix alias column alignment

### DIFF
--- a/LFGAnalyzer.lua
+++ b/LFGAnalyzer.lua
@@ -155,7 +155,7 @@ local function createConfigUI()
     f.aliasEntries = {}
     f.aliasRows = {}
     f.aliasContainer = CreateFrame("Frame", nil, content)
-    f.aliasContainer:SetPoint("TOPLEFT", f.aliasHeaderRaid, "BOTTOMLEFT", 0, -5)
+    f.aliasContainer:SetPoint("TOPLEFT", f.aliasHeaderAlias, "BOTTOMLEFT", 0, -5)
     f.aliasContainer:SetSize(360, 1)
 
     function refreshAliasList()


### PR DESCRIPTION
## Summary
- align alias list container with Alias header to avoid a column shift

## Testing
- `luac -p LFGAnalyzer.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688146e740f8832b9c30a0b65a0ae50f